### PR TITLE
[A-1] docs: log A-1 kickoff

### DIFF
--- a/kanban/board.md
+++ b/kanban/board.md
@@ -1,7 +1,6 @@
 # Kanban Board (Initial Setup)
 
 ## Backlog
-- A-1-kanban-scaffolding
 - A-2-ci-setup
 - A-3-data-model-migrations
 - A-4-auth-rls-baseline
@@ -20,7 +19,7 @@
 - _None_
 
 ## In Progress
-- _None_
+- A-1-kanban-scaffolding
 
 ## In Review
 - _None_

--- a/kanban/daily.md
+++ b/kanban/daily.md
@@ -2,3 +2,4 @@
 
 | Date | Done | Next | Blocked | Risks & Mitigations | Links |
 | --- | --- | --- | --- | --- | --- |
+| 2025-10-04 | Moved A-1 to In Progress; reviewed scaffolding assets | Validate acceptance criteria for A-1 | None | N/A | [A-1](issues/A-1-kanban-scaffolding.md) |

--- a/kanban/issues/A-1-kanban-scaffolding.md
+++ b/kanban/issues/A-1-kanban-scaffolding.md
@@ -48,10 +48,26 @@ Set up the repository-backed Kanban system, templates, and initial documentation
 ## Design Notes & Decisions
 
 ## Implementation Log
-- YYYY-MM-DD: 
+UTC 2025-10-04 11:25  branch=feature/A-1-kanban-scaffolding
+$ git checkout -b feature/A-1-kanban-scaffolding
+Result: OK
+
+UTC 2025-10-04 11:27
+Action: Update kanban board to move A-1 to In Progress
+Expected: Backlog removes A-1; In Progress lists A-1-kanban-scaffolding
+Actual: OK
+Files: kanban/board.md
+
+UTC 2025-10-04 11:29
+Action: Log progress in issue Implementation Log and kanban daily log
+Expected: Issue history captures branch setup; daily log shows current focus
+Actual: OK
+Files: kanban/issues/A-1-kanban-scaffolding.md, kanban/daily.md
 
 ## Commands Executed
-- 
+- `git checkout -b feature/A-1-kanban-scaffolding`
+- `apply_patch` updates to kanban/board.md
+- `apply_patch` updates to kanban/issues/A-1-kanban-scaffolding.md and kanban/daily.md
 
 ## Test Evidence
 - 


### PR DESCRIPTION
## Summary
- move A-1 card from Backlog to In Progress on the kanban board
- capture branch creation and progress notes inside the A-1 issue log
- record the daily log entry for the active A-1 workstream

## Related Issue
- [A-1](kanban/issues/A-1-kanban-scaffolding.md)

## Change Details
- Implementation Notes: Updated board, issue log, and daily log per workflow requirements.
- Impact Surface: Documentation only
- Regression Risks: None
- Security Notes: N/A

## Testing
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] E2E Tests
- [ ] Accessibility Checks
- [ ] Performance Checks
- [ ] Security Checks
- [ ] Manual QA

### Test Evidence
- Command(s): N/A
- Results: N/A

## Documentation Updates
- [ ] README / User Docs
- [ ] Architectural Notes
- [ ] PRD Coverage Updated
- [x] Kanban Issue Updated

## Screenshots / Recordings
- [x] Not Applicable

## Accessibility Notes
- Keyboard Navigation: N/A
- Screen Reader: N/A
- prefers-reduced-motion: N/A
- Color Contrast: N/A

## Known Limitations / Follow-ups
- None

------
https://chatgpt.com/codex/tasks/task_e_68e104155d78832fb409708a9b117eb6